### PR TITLE
blended on paper background effect 

### DIFF
--- a/apps/tohsaka.app/.editorconfig
+++ b/apps/tohsaka.app/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = tab
+indent_size = 2

--- a/apps/tohsaka.app/src/components/PosterGallery.tsx
+++ b/apps/tohsaka.app/src/components/PosterGallery.tsx
@@ -5,9 +5,15 @@ const PosterItem: React.FC<{ anime: Anime }> = ({ anime }) => {
 	const url = `https://api.tohsaka.app/anime/${anime.slug}/media/poster`;
 
 	return (
-		<div className="relative flex grow brightness-[.2] saturate-50">
-			<div className="w-full absolute top-0 left-0 bg-black/40 blur-[3px] h-[10px] transform -translate-y-1/2" />
-			<div className="w-[10px] absolute top-0 left-full bg-black/40 blur-[3px] h-full transform -translate-x-1/2" />
+		<div className="relative flex grow brightness-[.2] saturate-50 sepia">
+			{/* add's a blurred border to the right of the screen  */}
+			<div className="w-full h-[3px] absolute top-0 left-0 bg-gray-200 mix-blend-difference blur-[3px] transform -translate-y-1/2" />
+			<div className="w-full h-[1.5px] absolute top-0 left-0 bg-gray-500 blur-[1.5px] transform -translate-y-1/2" />
+
+			{/* add's a blurred border to the left screen */}
+			<div className="w-[3px] h-full absolute top-0 left-0 bg-gray-200 mix-blend-difference blur-[3px] transform -translate-x-1/2" />
+			<div className="w-[1.5px] h-full absolute top-0 left-0 bg-gray-500 blur-[1.5px] transform -translate-x-1/2" />
+
 			<div
 				className="h-screen w-full grow bg-cover bg-center md:h-96 md:w-64"
 				style={{

--- a/apps/tohsaka.app/src/components/PosterGallery.tsx
+++ b/apps/tohsaka.app/src/components/PosterGallery.tsx
@@ -1,5 +1,4 @@
 import { Anime, AnimeArray } from "@tohsaka/types";
-import { useEffect, useState } from "react";
 import useSWR from "swr";
 
 const PosterItem: React.FC<{ anime: Anime }> = ({ anime }) => {
@@ -7,10 +6,12 @@ const PosterItem: React.FC<{ anime: Anime }> = ({ anime }) => {
 
 	return (
 		<div className="relative flex grow brightness-[.2] saturate-50">
+			<div className="w-full absolute top-0 left-0 bg-black/40 blur-[3px] h-[10px] transform -translate-y-1/2" />
+			<div className="w-[10px] absolute top-0 left-full bg-black/40 blur-[3px] h-full transform -translate-x-1/2" />
 			<div
 				className="h-screen w-full grow bg-cover bg-center md:h-96 md:w-64"
 				style={{
-					backgroundImage: `url(${url})`
+					backgroundImage: `url(${url})`,
 				}}
 			/>
 		</div>

--- a/apps/tohsaka.app/tailwind.config.js
+++ b/apps/tohsaka.app/tailwind.config.js
@@ -1,12 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{tsx,ts,js,jsx}"],
-  theme: {
-    extend: {
-      fontFamily: {
-        lato: ["Lato", "sans-serif"]
-      }
-    },
-  },
-  plugins: [],
-}
+	content: ["./src/**/*.{tsx,ts,js,jsx}"],
+	theme: {
+		extend: {
+			fontFamily: {
+				lato: ["Lato", "sans-serif"],
+			},
+		},
+	},
+	plugins: [],
+};


### PR DESCRIPTION
# TLDR
this PR uses [serpia](https://tailwindcss.com/docs/sepia) to create a nice on paper feel on each poster image and then I apply a two layer border with some [mix blending](https://web.dev/learn/css/blend-modes/) to make it feel less sharp and some depth  

## Important notice
there is a past PR (#2) that branched of a me, that adds a more suttle effect that you could also opt for. you should pick pick one and close the other (if you choose one at all). 

# Before 
![image](https://user-images.githubusercontent.com/39814328/177983057-cc4d87d6-8862-43b3-88ff-ea594c5d1dbf.png)

# After
![image](https://user-images.githubusercontent.com/39814328/177983281-f9a11038-0983-4c20-a113-6944f672376e.png)
